### PR TITLE
Add default alerting rules for patch-operator

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,6 +16,7 @@ parameters:
 
     helm_values:
       enableCertManager: true
+      enableMonitoring: ${patch_operator:monitoring_enabled}
 
     monitoring_enabled: true
 
@@ -26,7 +27,6 @@ parameters:
           annotations:
             description: Patch operator controller {{$labels.controller}} has a high reconcile time for 10 minutes
             message: Patch operator controller {{$labels.controller}} has a high reconcile time for 10 minutes
-            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
             summary: Patch operator controller has a high reconcile time for 10 minutes
           expr: |
             1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="${patch_operator:namespace}", controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="${patch_operator:namespace}", controller=~"openapi-watcher|patch"}[5m]) > 0.25
@@ -39,7 +39,6 @@ parameters:
           annotations:
             description: Patch operator controller {{$labels.controller}} has reconciliation errors
             message: Patch operator controller {{$labels.controller}} has reconciliation errors
-            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileErrors.html
             summary: Patch operator controller has reconciliation errors
           expr: |
             rate(controller_runtime_reconcile_total{namespace="${patch_operator:namespace}", controller!~"openapi-watcher|patch", result="error"}[5m]) > 0

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,3 +16,31 @@ parameters:
 
     helm_values:
       enableCertManager: true
+
+    monitoring_enabled: true
+
+    alerts:
+      PatchReconcileSlow:
+        enabled: true
+        rule:
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has a high reconcile time for 10 minutes
+            message: Patch operator controller {{$labels.controller}} has a high reconcile time for 10 minutes
+            summary: Patch operator controller has a high reconcile time for 10 minutes
+          expr: |
+            1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="${patch_operator:namespace}", controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="${patch_operator:namespace}", controller=~"openapi-watcher|patch"}[5m]) > 0.25
+          for: 10m
+          labels:
+            severity: warning
+      PatchReconcileErrors:
+        enabled: true
+        rule:
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has reconciliation errors
+            message: Patch operator controller {{$labels.controller}} has reconciliation errors
+            summary: Patch operator controller has reconciliation errors
+          expr: |
+            rate(controller_runtime_reconcile_total{namespace="${patch_operator:namespace}", controller!~"openapi-watcher|patch", result="error"}[5m]) > 0
+          for: 4m
+          labels:
+            severity: warning

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -26,6 +26,7 @@ parameters:
           annotations:
             description: Patch operator controller {{$labels.controller}} has a high reconcile time for 10 minutes
             message: Patch operator controller {{$labels.controller}} has a high reconcile time for 10 minutes
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
             summary: Patch operator controller has a high reconcile time for 10 minutes
           expr: |
             1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="${patch_operator:namespace}", controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="${patch_operator:namespace}", controller=~"openapi-watcher|patch"}[5m]) > 0.25
@@ -38,6 +39,7 @@ parameters:
           annotations:
             description: Patch operator controller {{$labels.controller}} has reconciliation errors
             message: Patch operator controller {{$labels.controller}} has reconciliation errors
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileErrors.html
             summary: Patch operator controller has reconciliation errors
           expr: |
             rate(controller_runtime_reconcile_total{namespace="${patch_operator:namespace}", controller!~"openapi-watcher|patch", result="error"}[5m]) > 0

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -7,6 +7,8 @@ local params = inv.parameters.patch_operator;
 
 local ocp4 = inv.parameters.facts.distribution == 'openshift4';
 
+local monitoring = import 'monitoring.jsonnet';
+
 local patch_sa = kube.ServiceAccount(params.patch_serviceaccount.name) {
   metadata+: {
     namespace: params.namespace,
@@ -32,9 +34,10 @@ local patch_rbac = [
   '00_namespace': kube.Namespace(params.namespace) {
     metadata+: {
       labels+: {
-        [if ocp4 then 'openshift.io/cluster-monitoring']: 'true',
+        [if ocp4 && params.monitoring_enabled then 'openshift.io/cluster-monitoring']: 'true',
       },
     },
   },
   '10_rbac': patch_rbac,
+  [if params.monitoring_enabled then '30_monitoring']: monitoring,
 }

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -1,0 +1,33 @@
+local com = import 'lib/commodore.libjsonnet';
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.patch_operator;
+
+local alertlabels = {
+  syn: 'true',
+  syn_component: 'patch-operator',
+};
+
+local alerts = function(name, groupName, alerts)
+  com.namespaced(params.namespace, kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', name) {
+    spec+: {
+      groups+: [
+        {
+          name: groupName,
+          rules:
+            std.filterMap(
+              function(field) alerts[field].enabled == true,
+              function(field) alerts[field].rule {
+                alert: field,
+                labels+: alertlabels,
+              },
+              std.objectFields(alerts)
+            ),
+        },
+      ],
+    },
+  });
+
+[ alerts('patch-operator-prometheus-rule', 'patch.alerts', params.alerts) ]

--- a/component/monitoring.jsonnet
+++ b/component/monitoring.jsonnet
@@ -9,6 +9,7 @@ local alertlabels = {
   syn: 'true',
   syn_component: 'patch-operator',
 };
+local runbook_url(name) = 'https://hub.syn.tools/patch-operator/runbooks/%s.html' % [ name ];
 
 local alerts = function(name, groupName, alerts)
   com.namespaced(params.namespace, kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', name) {
@@ -22,6 +23,9 @@ local alerts = function(name, groupName, alerts)
               function(field) alerts[field].rule {
                 alert: field,
                 labels+: alertlabels,
+                annotations+: {
+                  runbook_url: runbook_url(field),
+                },
               },
               std.objectFields(alerts)
             ),

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -65,3 +65,57 @@ The Helm values to use to render the `patch-operator` helm chart.
 We enable cert-manager integration for the admission webhook serving certificates by default.
 
 NOTE: If you install the component on a cluster which doesn't have cert-manager installed, please disable this value and ensure webhook serving certificates are made available through parameter `external_certificates`.
+
+== `monitoring_enabled`
+
+[horizontal]
+type:: bool
+default:: `true`
+
+On OpenShift 4, the component sets label `openshift.io/cluster-monitoring=true` on the namespace, so that the patch operator `ServiceMonitor` object is picked up by the OpenShift 4 cluster monitoring stack.
+The component generates a `PrometheusRule` object with alerts as defined in `alerts`.
+
+== `alerts`
+
+[horizontal]
+type:: dict
+example::
++
+[source,yaml]
+----
+BadThingsHappening:
+  enabled: true
+  rule:
+    annotations:
+      description: Bad things have been happening on {{$labels.node}} for more than 10 minutes.
+      message: Bad things have been happening on {{$labels.node}} for more than 10 minutes.
+      runbook_url: https://hub.syn.tools/patch-operator/runbooks/BadThingsHappening.html
+    expr: |
+      bad_thing_happening == 1
+    for: 10m
+    labels:
+      severity: warning
+----
+
+
+`alerts` defines the alerts to be installed.
+The dictionary key is used as the name of the alert.
+Note that `alerts` is ignored if `monitoring_enabled` is set to `false`.
+
+
+=== `alerts.<name>.enabled`
+
+[horizontal]
+type:: bool
+
+Defines whether to install the alert.
+
+
+=== `alerts.<name>.rule`
+
+[horizontal]
+type:: dict
+
+Holds the configuration of the alert rule.
+
+See https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[Prometheus Alerting Rules] for details.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -79,6 +79,7 @@ The component generates a `PrometheusRule` object with alerts as defined in `ale
 
 [horizontal]
 type:: dict
+defaults:: https://github.com/projectsyn/component-patch-operator/blob/master/class/defaults.yml[See `class/defaults.yml`]
 example::
 +
 [source,yaml]

--- a/docs/modules/ROOT/pages/runbooks/PatchReconcileErrors.adoc
+++ b/docs/modules/ROOT/pages/runbooks/PatchReconcileErrors.adoc
@@ -21,5 +21,5 @@ $ kubectl -n syn-patch-operator logs deploy/patch-operator -c patch-operator
 
 [source,shell]
 ----
-$ kubectl -n syn-patch-operator get patch <PATCH_NAME>
+$ kubectl -n syn-patch-operator get patch -o yaml <PATCH_NAME>
 ----

--- a/docs/modules/ROOT/pages/runbooks/PatchReconcileErrors.adoc
+++ b/docs/modules/ROOT/pages/runbooks/PatchReconcileErrors.adoc
@@ -1,0 +1,25 @@
+= Alert rule: PatchReconcileErrors
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires if any patch reconciliation results in an error.
+
+== icon:bug[] Steps for debugging
+
+
+=== Check the logs of patch-operator
+
+[source,shell]
+----
+$ kubectl -n syn-patch-operator logs deploy/patch-operator -c patch-operator
+----
+
+
+=== Check the status of the patch resource referenced in the alert
+
+[source,shell]
+----
+$ kubectl -n syn-patch-operator get patch <PATCH_NAME>
+----

--- a/docs/modules/ROOT/pages/runbooks/PatchReconcileSlow.adoc
+++ b/docs/modules/ROOT/pages/runbooks/PatchReconcileSlow.adoc
@@ -1,0 +1,24 @@
+= Alert rule: PatchReconcileSlow
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires if more than 25% of operations within a 5-minute sliding window take longer than 1 second.
+
+== icon:bug[] Steps for debugging
+
+
+=== Check the logs of patch-operator
+
+[source,shell]
+----
+$ kubectl -n syn-patch-operator logs deploy/patch-operator -c patch-operator
+----
+
+
+=== Check the status of the patch resource referenced in the alert
+
+[source,shell]
+----
+$ kubectl -n syn-patch-operator get patch <PATCH_NAME>
+----

--- a/docs/modules/ROOT/pages/runbooks/PatchReconcileSlow.adoc
+++ b/docs/modules/ROOT/pages/runbooks/PatchReconcileSlow.adoc
@@ -20,5 +20,5 @@ $ kubectl -n syn-patch-operator logs deploy/patch-operator -c patch-operator
 
 [source,shell]
 ----
-$ kubectl -n syn-patch-operator get patch <PATCH_NAME>
+$ kubectl -n syn-patch-operator get patch -o yaml <PATCH_NAME>
 ----

--- a/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
+++ b/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Please consider opening a PR to improve this runbook if you gain new information about causes of the alert, or how to debug or resolve the alert.
+Click "Edit this Page" in the top right corner to create a PR directly on GitHub.
+====

--- a/lib/patch-operator.libsonnet
+++ b/lib/patch-operator.libsonnet
@@ -80,7 +80,7 @@ local patch(name, saName, targetobjref, patchtemplate, patchtype='application/st
         name: saName,
       },
       patches: {
-        patch1: {
+        [name + '-patch']: {
           targetObjectRef: targetobjref,
           patchTemplate: std.manifestYamlDoc(patchtemplate),
           patchType: patchtype,

--- a/tests/golden/defaults/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/defaults/patch-operator/patch-operator/30_monitoring.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: patch-operator-prometheus-rule
+  name: patch-operator-prometheus-rule
+  namespace: syn-patch-operator
+spec:
+  groups:
+    - name: patch.alerts
+      rules:
+        - alert: PatchReconcileErrors
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has reconciliation
+              errors
+            message: Patch operator controller {{$labels.controller}} has reconciliation
+              errors
+            summary: Patch operator controller has reconciliation errors
+          expr: 'rate(controller_runtime_reconcile_total{namespace="syn-patch-operator",
+            controller!~"openapi-watcher|patch", result="error"}[5m]) > 0
+
+            '
+          for: 4m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: patch-operator
+        - alert: PatchReconcileSlow
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has a high
+              reconcile time for 10 minutes
+            message: Patch operator controller {{$labels.controller}} has a high reconcile
+              time for 10 minutes
+            summary: Patch operator controller has a high reconcile time for 10 minutes
+          expr: '1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator",
+            controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator",
+            controller=~"openapi-watcher|patch"}[5m]) > 0.25
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: patch-operator

--- a/tests/golden/defaults/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/defaults/patch-operator/patch-operator/30_monitoring.yaml
@@ -16,6 +16,7 @@ spec:
               errors
             message: Patch operator controller {{$labels.controller}} has reconciliation
               errors
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileErrors.html
             summary: Patch operator controller has reconciliation errors
           expr: 'rate(controller_runtime_reconcile_total{namespace="syn-patch-operator",
             controller!~"openapi-watcher|patch", result="error"}[5m]) > 0
@@ -32,6 +33,7 @@ spec:
               reconcile time for 10 minutes
             message: Patch operator controller {{$labels.controller}} has a high reconcile
               time for 10 minutes
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
             summary: Patch operator controller has a high reconcile time for 10 minutes
           expr: '1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator",
             controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator",

--- a/tests/golden/external-certificates/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/external-certificates/patch-operator/patch-operator/30_monitoring.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: patch-operator-prometheus-rule
+  name: patch-operator-prometheus-rule
+  namespace: syn-patch-operator
+spec:
+  groups:
+    - name: patch.alerts
+      rules:
+        - alert: PatchReconcileErrors
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has reconciliation
+              errors
+            message: Patch operator controller {{$labels.controller}} has reconciliation
+              errors
+            summary: Patch operator controller has reconciliation errors
+          expr: 'rate(controller_runtime_reconcile_total{namespace="syn-patch-operator",
+            controller!~"openapi-watcher|patch", result="error"}[5m]) > 0
+
+            '
+          for: 4m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: patch-operator
+        - alert: PatchReconcileSlow
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has a high
+              reconcile time for 10 minutes
+            message: Patch operator controller {{$labels.controller}} has a high reconcile
+              time for 10 minutes
+            summary: Patch operator controller has a high reconcile time for 10 minutes
+          expr: '1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator",
+            controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator",
+            controller=~"openapi-watcher|patch"}[5m]) > 0.25
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: patch-operator

--- a/tests/golden/external-certificates/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/external-certificates/patch-operator/patch-operator/30_monitoring.yaml
@@ -16,6 +16,7 @@ spec:
               errors
             message: Patch operator controller {{$labels.controller}} has reconciliation
               errors
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileErrors.html
             summary: Patch operator controller has reconciliation errors
           expr: 'rate(controller_runtime_reconcile_total{namespace="syn-patch-operator",
             controller!~"openapi-watcher|patch", result="error"}[5m]) > 0
@@ -32,6 +33,7 @@ spec:
               reconcile time for 10 minutes
             message: Patch operator controller {{$labels.controller}} has a high reconcile
               time for 10 minutes
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
             summary: Patch operator controller has a high reconcile time for 10 minutes
           expr: '1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator",
             controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator",

--- a/tests/golden/lib/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/lib/patch-operator/patch-operator/30_monitoring.yaml
@@ -1,0 +1,45 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: patch-operator-prometheus-rule
+  name: patch-operator-prometheus-rule
+  namespace: syn-patch-operator
+spec:
+  groups:
+    - name: patch.alerts
+      rules:
+        - alert: PatchReconcileErrors
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has reconciliation
+              errors
+            message: Patch operator controller {{$labels.controller}} has reconciliation
+              errors
+            summary: Patch operator controller has reconciliation errors
+          expr: 'rate(controller_runtime_reconcile_total{namespace="syn-patch-operator",
+            controller!~"openapi-watcher|patch", result="error"}[5m]) > 0
+
+            '
+          for: 4m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: patch-operator
+        - alert: PatchReconcileSlow
+          annotations:
+            description: Patch operator controller {{$labels.controller}} has a high
+              reconcile time for 10 minutes
+            message: Patch operator controller {{$labels.controller}} has a high reconcile
+              time for 10 minutes
+            summary: Patch operator controller has a high reconcile time for 10 minutes
+          expr: '1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator",
+            controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator",
+            controller=~"openapi-watcher|patch"}[5m]) > 0.25
+
+            '
+          for: 10m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: patch-operator

--- a/tests/golden/lib/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/lib/patch-operator/patch-operator/30_monitoring.yaml
@@ -16,6 +16,7 @@ spec:
               errors
             message: Patch operator controller {{$labels.controller}} has reconciliation
               errors
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileErrors.html
             summary: Patch operator controller has reconciliation errors
           expr: 'rate(controller_runtime_reconcile_total{namespace="syn-patch-operator",
             controller!~"openapi-watcher|patch", result="error"}[5m]) > 0
@@ -32,6 +33,7 @@ spec:
               reconcile time for 10 minutes
             message: Patch operator controller {{$labels.controller}} has a high reconcile
               time for 10 minutes
+            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
             summary: Patch operator controller has a high reconcile time for 10 minutes
           expr: '1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator",
             controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator",

--- a/tests/golden/lib/patch-operator/tests/test-patch-long-name.yaml
+++ b/tests/golden/lib/patch-operator/tests/test-patch-long-name.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: syn-patch-operator
 spec:
   patches:
-    patch1:
+    clusterrolebinding-system-build-strategy-docker-4b7cc202c83ea43-patch:
       patchTemplate: "\"annotations\":\n  \"rbac.authorization.kubernetes.io/autoupdate\"\
         : \"false\""
       patchType: application/strategic-merge-patch+json

--- a/tests/golden/lib/patch-operator/tests/test-patch.yaml
+++ b/tests/golden/lib/patch-operator/tests/test-patch.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: syn-patch-operator
 spec:
   patches:
-    patch1:
+    foo-test-d8c672cc5067d92-patch:
       patchTemplate: "\"spec\":\n  \"replicas\": 5"
       patchType: application/strategic-merge-patch+json
       targetObjectRef:


### PR DESCRIPTION
With this change, patch-operator will generate a prometheus rule with alerts based on the operator's metrics. The alerts are configurable. By default, alerts are included on patch reconciliation errors as well as high patch reconciliation latency. 

The default alert thresholds (to be tuned in productive use) are:
* Error rate: Any error will result in an alert
* Latency: If more than 25% of operations within a 5-minute sliding window take longer than 1 second, alert.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
