### PR TITLE
Mark component as replacement for component `resource-locker`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,6 +1,9 @@
 parameters:
   patch_operator:
-    =_metadata: {}
+    =_metadata:
+      replaces: resource-locker
+      library_aliases:
+        resource-locker.libjsonnet: patch-operator-migrate.libsonnet
     namespace: syn-patch-operator
 
     patch_serviceaccount:

--- a/lib/patch-operator-migrate.libsonnet
+++ b/lib/patch-operator-migrate.libsonnet
@@ -2,7 +2,7 @@ local p = std.trace(
   'importing resource-locker.libjsonnet is deprecated, ' +
   "please switch to `import 'patch-operator.libsonnet'`. " +
   'See https://hub.syn.tools/patch-operator/how-tos/migrate-from-resource-locker.html for more details.',
-  import 'patch-operator.libsonnet'
+  import 'lib/patch-operator.libsonnet'
 );
 
 local Resource(obj) =

--- a/lib/patch-operator-migrate.libsonnet
+++ b/lib/patch-operator-migrate.libsonnet
@@ -1,7 +1,7 @@
 local p = std.trace(
   'importing resource-locker.libjsonnet is deprecated, ' +
   "please switch to `import 'patch-operator.libsonnet'`. " +
-  'See https://hub.syn.tools/patch-operator/how-tos/migrating-from-resource-locker.html for more details.',
+  'See https://hub.syn.tools/patch-operator/how-tos/migrate-from-resource-locker.html for more details.',
   import 'patch-operator.libsonnet'
 );
 


### PR DESCRIPTION
See also https://github.com/projectsyn/component-resource-locker/pull/73


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
