### PR TITLE
Add missing ArgoCD sync options for `Patch` resources

### DIFF
--- a/lib/patch-operator.libsonnet
+++ b/lib/patch-operator.libsonnet
@@ -74,6 +74,9 @@ local patch(name, saName, targetobjref, patchtemplate, patchtype='application/st
   kube._Object(apiVersion, 'Patch', name) {
     metadata+: {
       namespace: namespace,
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
     },
     spec+: {
       serviceAccountRef: {

--- a/tests/golden/lib/patch-operator/tests/test-patch-long-name.yaml
+++ b/tests/golden/lib/patch-operator/tests/test-patch-long-name.yaml
@@ -1,7 +1,8 @@
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: Patch
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: clusterrolebinding-system-build-strategy-docker-4b7cc202c83ea43
   name: clusterrolebinding-system-build-strategy-docker-4b7cc202c83ea43

--- a/tests/golden/lib/patch-operator/tests/test-patch.yaml
+++ b/tests/golden/lib/patch-operator/tests/test-patch.yaml
@@ -1,7 +1,8 @@
 apiVersion: redhatcop.redhat.io/v1alpha1
 kind: Patch
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: foo-test-d8c672cc5067d92
   name: foo-test-d8c672cc5067d92


### PR DESCRIPTION
We want to keep ArgoCD sync option `SkipDryRunOnMissingResource=true` for `Patch` resources to allow cluster catalogs to be deployed on newly provisioned clusters with a minimum of manual effort.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
