### PR TITLE
Fix external certificate support for admission webhook

### DIFF
--- a/docs/modules/ROOT/pages/how-tos/external-certificates.adoc
+++ b/docs/modules/ROOT/pages/how-tos/external-certificates.adoc
@@ -46,9 +46,9 @@ webhook=patch-operator-webhook-service.${operator_ns}.svc
 metrics=patch-operator-controller-manager-metrics-service.${operator_ns}.svc
 
 openssl req -x509 -newkey rsa:4096 -nodes -keyout webhook.key -out webhook.crt -days ${lifetime} \
-  -subj "/CN=$webhook" -addext "subjectAltName = DNS:$webhook,DNS:${webhook}.cluster.local"
+  -subj "/CN=webhook" -addext "subjectAltName = DNS:$webhook,DNS:${webhook}.cluster.local"
 openssl req -x509 -newkey rsa:4096 -nodes -keyout metrics.key -out metrics.crt -days ${lifetime} \
-  -subj "/CN=$metrics" -addext "subjectAltName = DNS:$metrics,DNS:${metrics}.cluster.local"
+  -subj "/CN=metrics" -addext "subjectAltName = DNS:$metrics,DNS:${metrics}.cluster.local"
 ----
 <1> Update if you're installing the patch operator in a different namespace.
 You can extract the actual operator namespace from the inventory with `kapitan inventory -t patch-operator | yq '.parameters.patch_operator.namespace'`.

--- a/docs/modules/ROOT/pages/how-tos/external-certificates.adoc
+++ b/docs/modules/ROOT/pages/how-tos/external-certificates.adoc
@@ -64,8 +64,7 @@ vault login -metod=oidc <2>
 
 parent="clusters/kv/${TENANT_ID}/${CLUSTER_ID}"
 
-vault kv put $parent/patch-operator webhook-key=@webhook.key
-vault kv put $parent/patch-operator metrics-key=@metrics.key
+vault kv put $parent/patch-operator webhook-key=@webhook.key metrics-key=@metrics.key
 ----
 <1> Replace with the URL of your Project Syn Vault instance.
 <2> This assumes that your Vault instance is setup with OIDC login for users.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -41,6 +41,15 @@ Supported keys are `tls.key`, `tls.crt` and `ca.crt`.
 The component will generate secrets with type `kubernetes.io/tls` and the provided keys.
 If key `ca.crt` is missing, the component assumes that `tls.crt` is a self-signed certificate.
 
+[IMPORTANT]
+====
+The certificate must be provided directly in the hierarchy, rather than as a secret reference.
+
+When field `tls.crt` or `ca.crt` are provided as secret references, the component will generate invalid admission webhook configurations if the certificates are provided as PEM-encoded.
+To get valid admission webhook configs with secret references, the certificates would have to be base64-encoded PEM-encoded certificates.
+However, by base64-encoding the certificates in Vault, we'd get an invalid certificate secret, since we always emit the secrets with the certificate values in field `stringData`.
+====
+
 == `charts`
 
 [horizontal]

--- a/postprocess/fixup-helm-chart.jsonnet
+++ b/postprocess/fixup-helm-chart.jsonnet
@@ -31,11 +31,19 @@ local fixupFn(obj) =
         w {
           clientConfig+: {
             // use ca.crt if specified, and assume self-signed cert otherwise.
-            caBundle: std.get(
+            local caBundle = std.get(
               external_certs.webhook,
               'ca.crt',
               external_certs.webhook['tls.crt']
             ),
+            // caBundle is expected to be base64-encoded, we encode here, if
+            // the provided caBundle value looks like a PEM-encoded
+            // certificate (i.e. starts with "-----BEGIN CERTIFICATE-----").
+            caBundle:
+              if std.startsWith(caBundle, '-----BEGIN CERTIFICATE-----') then
+                std.base64(caBundle)
+              else
+                caBundle,
           },
         }
         for w in super.webhooks

--- a/tests/external-certificates.yml
+++ b/tests/external-certificates.yml
@@ -7,7 +7,10 @@ parameters:
       webhook:
         tls.key: ?{vaultkv:${cluster:tenant}/${cluster:name}/patch-operator/webhook-cert/key}
         tls.crt: ?{vaultkv:${cluster:tenant}/${cluster:name}/patch-operator/webhook-cert/cert}
-        ca.crt: ?{vaultkv:${cluster:tenant}/${cluster:name}/patch-operator/webhook-cert/cacert}
+        ca.crt: |-
+          -----BEGIN CERTIFICATE-----
+          MII.....
+          -----END CERTIFICATE-----
 
     helm_values:
       enableCertManager: false

--- a/tests/golden/external-certificates/patch-operator/patch-operator/01_helm_chart/patch-operator/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_patch-operator-mutating-webhook-configuration.yaml
+++ b/tests/golden/external-certificates/patch-operator/patch-operator/01_helm_chart/patch-operator/templates/admissionregistration.k8s.io_v1_mutatingwebhookconfiguration_patch-operator-mutating-webhook-configuration.yaml
@@ -9,7 +9,7 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: ?{vaultkv:t-silent-test-1234/c-green-test-1234/patch-operator/webhook-cert/cacert}
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSS4uLi4uCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
       service:
         name: patch-operator-webhook-service
         namespace: syn-patch-operator

--- a/tests/golden/external-certificates/patch-operator/patch-operator/01_helm_chart/patch-operator/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_patch-operator-validating-webhook-configuration.yaml
+++ b/tests/golden/external-certificates/patch-operator/patch-operator/01_helm_chart/patch-operator/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_patch-operator-validating-webhook-configuration.yaml
@@ -9,7 +9,7 @@ webhooks:
   - admissionReviewVersions:
       - v1
     clientConfig:
-      caBundle: ?{vaultkv:t-silent-test-1234/c-green-test-1234/patch-operator/webhook-cert/cacert}
+      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSS4uLi4uCi0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0=
       service:
         name: patch-operator-webhook-service
         namespace: syn-patch-operator

--- a/tests/golden/external-certificates/patch-operator/patch-operator/20_external_certificates.yaml
+++ b/tests/golden/external-certificates/patch-operator/patch-operator/20_external_certificates.yaml
@@ -19,7 +19,11 @@ metadata:
     name: webhook-server-cert
   name: webhook-server-cert
 stringData:
-  ca.crt: t-silent-test-1234/c-green-test-1234/patch-operator/webhook-cert/cacert
+  ca.crt: '-----BEGIN CERTIFICATE-----
+
+    MII.....
+
+    -----END CERTIFICATE-----'
   tls.crt: t-silent-test-1234/c-green-test-1234/patch-operator/webhook-cert/cert
   tls.key: t-silent-test-1234/c-green-test-1234/patch-operator/webhook-cert/key
 type: kubernetes.io/tls


### PR DESCRIPTION
When the external certificate is provided directly in the hierarchy (and not through a secret reference), we need to base64-encode the value for the admission webhook configurations.

Additionally, we fix some issues in the external certificates how-to which required manual fixing when deploying self-signed certificates on a cluster which doesn't have cert-manager available.



## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
