### PR TITLE
Disable PatchReconcileSlow alert by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -25,7 +25,7 @@ parameters:
 
     alerts:
       PatchReconcileSlow:
-        enabled: true
+        enabled: false
         rule:
           annotations:
             description: Patch operator controller {{$labels.controller}} has a high reconcile time for 10 minutes

--- a/tests/golden/defaults/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/defaults/patch-operator/patch-operator/30_monitoring.yaml
@@ -25,18 +25,3 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: patch-operator
-        - alert: PatchReconcileSlow
-          annotations:
-            description: Patch operator controller {{$labels.controller}} has a high
-              reconcile time for 10 minutes
-            message: Patch operator controller {{$labels.controller}} has a high reconcile
-              time for 10 minutes
-            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
-            summary: Patch operator controller has a high reconcile time for 10 minutes
-          expr: |
-            1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator", controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator", controller=~"openapi-watcher|patch"}[5m]) > 0.25
-          for: 10m
-          labels:
-            severity: warning
-            syn: 'true'
-            syn_component: patch-operator

--- a/tests/golden/external-certificates/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/external-certificates/patch-operator/patch-operator/30_monitoring.yaml
@@ -25,18 +25,3 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: patch-operator
-        - alert: PatchReconcileSlow
-          annotations:
-            description: Patch operator controller {{$labels.controller}} has a high
-              reconcile time for 10 minutes
-            message: Patch operator controller {{$labels.controller}} has a high reconcile
-              time for 10 minutes
-            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
-            summary: Patch operator controller has a high reconcile time for 10 minutes
-          expr: |
-            1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator", controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator", controller=~"openapi-watcher|patch"}[5m]) > 0.25
-          for: 10m
-          labels:
-            severity: warning
-            syn: 'true'
-            syn_component: patch-operator

--- a/tests/golden/lib/patch-operator/patch-operator/30_monitoring.yaml
+++ b/tests/golden/lib/patch-operator/patch-operator/30_monitoring.yaml
@@ -25,18 +25,3 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: patch-operator
-        - alert: PatchReconcileSlow
-          annotations:
-            description: Patch operator controller {{$labels.controller}} has a high
-              reconcile time for 10 minutes
-            message: Patch operator controller {{$labels.controller}} has a high reconcile
-              time for 10 minutes
-            runbook_url: https://hub.syn.tools/patch-operator/runbooks/PatchReconcileSlow.html
-            summary: Patch operator controller has a high reconcile time for 10 minutes
-          expr: |
-            1 - sum(rate(controller_runtime_reconcile_time_seconds_bucket{namespace="syn-patch-operator", controller=~"openapi-watcher|patch", le="1"}[5m])) without (le) / rate(controller_runtime_reconcile_time_seconds_count{namespace="syn-patch-operator", controller=~"openapi-watcher|patch"}[5m]) > 0.25
-          for: 10m
-          labels:
-            severity: warning
-            syn: 'true'
-            syn_component: patch-operator


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
